### PR TITLE
Added Cab Models

### DIFF
--- a/index.html
+++ b/index.html
@@ -1093,14 +1093,149 @@
             
             /* Cabs */
             
-            "HD2_Cab4X12CaliV30": {
-                "type": "cab",
-                "name": "4X12 Cali V30"
-            },
-            "HD2_Cab4x12XXLV30": {
-                "type": "cab",
-                "name": "4x12 XXL V30"
-            },
+		"HD2_Cab1x6x9SoupProEllipse": { 
+			"type": "cab", 
+			"name": "Soup Pro Ellipse" 
+		},
+		"HD2_Cab1x8SmallTweed": {
+			"type": "cab",
+			"name": "1x8 Small Tweed" 
+		},
+		"HD2_Cab1x12FieldCoil": {
+			"type": "cab", 
+			"name": "1x12 Field Coil"
+		},
+		"HD2_Cab1x12USDeluxe": {
+			"type": "cab", 
+			"name": "1x12 US Deluxe" 
+		},
+		"HD2_Cab1x12Celest12H": { 
+			"type": "cab", 
+			"name": "1x12 Celest 12H"
+		},
+		"HD2_Cab1x12BlueBell": { 
+			"type": "cab", 
+			"name": "1x12 Blue Bell"
+		},
+		"HD2_Cab1x12Lead80": {
+			"type": "cab", 
+			"name": "1x12 Lead 80" 
+		},
+		"HD2_Cab1x12CaliExt": { 
+			"type": "cab", 
+			"name": "1x12 Cali Ext"
+		},
+		"HD2_Cab1x12CaliIV": { 
+			"type": "cab", 
+			"name": "1x12 Cali IV" 
+		},
+		"HD2_Cab1x12DelSol": { 
+			"type": "cab", 
+			"name": "1x12 Del Sol" 
+		},
+		"HD2_Cab1x12MatchH30": { 
+			"type": "cab", 
+			"name": "1x12 Match H30"
+		},
+		"HD2_Cab1x12MatchG25": {
+			"type": "cab",
+			"name": "1x12 Match G25"
+		},
+		"HD2_Cab2x12DoubleC12N": {
+			"type": "cab", 
+			"name": "2x12 Double C12N"
+		},
+		"HD2_Cab2x12MailC12Q": {
+			"type": "cab", 
+			"name": "2x12 Mail C12Q"
+		},
+		"HD2_Cab2x12Interstate": { 
+			"type": "cab", 
+			"name": "2x12 Interstate"
+		},
+		"HD2_Cab2x12JazzRivet": { 
+			"type": "cab", 
+			"name": "2x12 Jazz Rivet" 
+		},
+		"HD2_Cab2x12SilverBell": { 
+			"type": "cab", 
+			"name": "2x12 Silver Bell" 
+		},
+		"HD2_Cab2x12BlueBell": {
+			"type": "cab", 
+			"name": "2x12 Blue Bell" 
+		},
+		"HD2_Cab4x10TweedP10R": { 
+			"type": "cab", 
+			"name": "4x10 Tweed P10R"
+		},
+		"HD2_Cab4x12WhoWatt100": { 
+			"type": "cab", 
+			"name": "4x12 WhoWatt 100"
+		},
+		"HD2_Cab4x12MandarinEM": { 
+			"type": "cab", 
+			"name": "4x12 Mandarin EM"
+		},
+		"HD2_Cab4x12Greenback25": {
+			"type": "cab", 
+			"name": "4x12 Greenback25"
+		},
+		"HD2_Cab4x12Greenback20": {
+			"type": "cab", 
+			"name": "4x12 Greenback20"
+		},
+		"HD2_Cab4x12Blackback30": { 
+			"type": "cab", 
+			"name": "4x12 Blackback30" 
+		},
+		"HD2_Cab4x121960T75": { 
+			"type": "cab", 
+			"name": "4x12 1960 T75" 
+		},
+		"HD2_Cab4x12UberV30": { 
+			"type": "cab", 
+			"name": "4x12 Uber V30"
+		},
+		"HD2_Cab4x12UberT75": { 
+			"type": "cab", 
+			"name": "4x12 Uber T75"
+		},
+		"HD2_Cab4X12CaliV30": {
+			"type": "cab", 
+			"name": "4x12 Cali V30" 
+		},
+		"HD2_Cab4x12XXLV30": { 
+			"type": "cab", 
+			"name": "4x12 XXL V30"
+		},
+		"HD2_Cab4x12SoloLeadEM": { 
+			"type": "cab", 
+			"name": "4x12 SoloLead EM"
+		},
+		"HD2_Cab1x15TucknGo": { 
+			"type": "cab", 
+			"name": "1x15 Tuck n' Go"
+		},
+		"HD2_Cab1x18DelSol": { 
+			"type": "cab",
+			"name": "1x18 Del Sol"
+		},
+		"HD2_Cab1x18WoodyBlue": { 
+			"type": "cab", "name": "1x18 Woody Blue"
+		},
+		"HD2_Cab2x15Brute": { 
+			"type": "cab", "name": "2x15 Brute"
+		},
+		"HD2_Cab4x10Rhino": { 
+			"type": "cab", "name": "4x10 Rhino"
+		},
+		"HD2_Cab6x10CaliPower": { 
+			"type": "cab", "name": "6x10 Cali Power"
+		},
+		"HD2_Cab8x10SVBeast": {
+			"type": "cab", "name": "8x10 SV Beast"
+		},
 
             /* Pitch */ 
             


### PR DESCRIPTION
Ordered by Helix 2.0 Manual

Following weren't in the list so I added them arbitrarily... 

"HD2_Cab1x12CaliExt"
"HD2_Cab1x12CaliIV"
"HD2_Cab1x12DelSol"
"HD2_Cab1x12MatchH30"
"HD2_Cab1x12MatchG25"
"HD2_Cab1x18DelSol"
"HD2_Cab1x18WoodyBlue"